### PR TITLE
Ensuring Flyway Checksum Are Correct

### DIFF
--- a/mentoring-core/.gitattributes
+++ b/mentoring-core/.gitattributes
@@ -1,0 +1,1 @@
+*.sql text eol=lf


### PR DESCRIPTION
Since the checksum is calculated using the file contents, having different line endings based on platforms results in different checksum something that is not desirable. This configuration attempts to fix this probelm